### PR TITLE
Redesign home page as clickable post cards; polish nav and styles

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,9 +1,9 @@
 <header class="site-header">
   <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
   <nav class="site-nav">
-    <a href="{{ '/' | relative_url }}">blog</a>
-    <a href="{{ '/tags/' | relative_url }}">tags</a>
-    <a href="{{ '/about/' | relative_url }}">about</a>
+    {% assign p = page.url | remove: 'index.html' %}
+    <a href="{{ '/about/' | relative_url }}"{% if p == '/about/' %} class="active"{% endif %}>about</a>
+    <a href="{{ '/tags/' | relative_url }}"{% if p == '/tags/' %} class="active"{% endif %}>tags</a>
     <a href="{{ '/feed.xml' | relative_url }}">rss</a>
   </nav>
 </header>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -13,6 +13,8 @@
   --accent: #b5240c;
   --border: #e3e3e0;
   --code-bg: #f3f3f0;
+  --card-bg: #ffffff;
+  --shadow: rgba(0, 0, 0, 0.06);
 
   --measure: 70ch;
   --space: 1.5rem;
@@ -26,6 +28,8 @@
     --accent: #ff7a5c;
     --border: #2a2a2a;
     --code-bg: #1c1c1c;
+    --card-bg: #161616;
+    --shadow: rgba(0, 0, 0, 0.4);
   }
 }
 
@@ -85,6 +89,7 @@ body {
 
 .site-nav a { color: var(--muted); text-decoration: none; }
 .site-nav a:hover { color: var(--accent); }
+.site-nav a.active { color: var(--fg); border-bottom: 1px solid var(--accent); }
 
 /* Links -------------------------------------------------------------------- */
 
@@ -127,6 +132,76 @@ a:hover { text-decoration: underline; }
 
 .post-item-link { text-decoration: none; color: var(--fg); }
 .post-item-link:hover { color: var(--accent); text-decoration: underline; }
+
+/* Post cards (home page) --------------------------------------------------- */
+
+.cards {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--card-bg);
+  transition: border-color 0.15s ease, transform 0.15s ease,
+              box-shadow 0.15s ease;
+}
+
+.card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px var(--shadow);
+}
+
+.card-link {
+  display: block;
+  padding: 1.25rem 1.4rem;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.card-date {
+  display: block;
+  color: var(--muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  margin-bottom: 0.3rem;
+}
+
+.card-title {
+  font-size: 1.2rem;
+  line-height: 1.3;
+  margin: 0 0 0.5rem;
+}
+
+.card:hover .card-title { color: var(--accent); }
+
+.card-blurb {
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.6;
+  margin: 0 0 0.75rem;
+}
+
+.card-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+}
+
+.card-tags .tag { font-size: 0.8rem; }
+
+.card-more {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--accent);
+  font-weight: 500;
+}
 
 /* Posts & pages ------------------------------------------------------------ */
 

--- a/index.html
+++ b/index.html
@@ -2,21 +2,26 @@
 layout: default
 title: Home
 ---
-<section class="intro">
-  <h1 class="intro-title">{{ site.title }}</h1>
-  <p class="intro-tagline">{{ site.tagline }}</p>
-</section>
-
 <section class="post-list">
-  <h2 class="section-heading">Writing</h2>
   {% if site.posts.size > 0 %}
-    <ul class="posts">
+    <ul class="cards">
       {% for post in site.posts %}
-        <li class="post-item">
-          <time class="post-item-date" datetime="{{ post.date | date_to_xmlschema }}">
-            {{ post.date | date: "%Y-%m-%d" }}
-          </time>
-          <a class="post-item-link" href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        <li class="card">
+          <a class="card-link" href="{{ post.url | relative_url }}">
+            <time class="card-date" datetime="{{ post.date | date_to_xmlschema }}">
+              {{ post.date | date: "%B %-d, %Y" }}
+            </time>
+            <h2 class="card-title">{{ post.title }}</h2>
+            <p class="card-blurb">
+              {{ post.description | default: post.excerpt | strip_html | normalize_whitespace | truncate: 160 }}
+            </p>
+            {% if post.tags and post.tags.size > 0 %}
+              <span class="card-tags">
+                {% for tag in post.tags %}<span class="tag">#{{ tag }}</span>{% endfor %}
+              </span>
+            {% endif %}
+            <span class="card-more">Read &rarr;</span>
+          </a>
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
- Home page now lists posts as clickable cards (date, title, blurb, tags, read-more) linking to the full post page
- Blurb uses post description, falling back to the excerpt
- Drop duplicate hero title (site title lives top-left in the header)
- Streamline nav (about/tags/rss) with an active-page indicator
- Add card styling with hover lift/shadow and light/dark card colors


Claude-Session: https://claude.ai/code/session_01L6D8nCWBGwrvQgT7zyCTX7